### PR TITLE
Remove boxsizing.htc reference - we never had this file from the start s...

### DIFF
--- a/src/css/dgu-ie7.less
+++ b/src/css/dgu-ie7.less
@@ -3,7 +3,7 @@
  * https://github.com/coliff/bootstrap-ie7 
  */
 
-.col-sm-1,.col-sm-2,.col-sm-3,.col-sm-4,.col-sm-5,.col-sm-6,.col-sm-7,.col-sm-8,.col-sm-9,.col-sm-10,.col-sm-11,.col-md-1,.col-md-2,.col-md-3,.col-md-4,.col-md-5,.col-md-6,.col-md-7,.col-md-8,.col-md-9,.col-md-10,.col-md-11,.input-group {box-sizing:border-box;behavior:url(/js/boxsizing.htc)}
+.col-sm-1,.col-sm-2,.col-sm-3,.col-sm-4,.col-sm-5,.col-sm-6,.col-sm-7,.col-sm-8,.col-sm-9,.col-sm-10,.col-sm-11,.col-md-1,.col-md-2,.col-md-3,.col-md-4,.col-md-5,.col-md-6,.col-md-7,.col-md-8,.col-md-9,.col-md-10,.col-md-11,.input-group {box-sizing:border-box}
 audio,canvas,video{display:inline;zoom:1}
 html{font-size:100%}
 img{width:auto;height:auto;-ms-interpolation-mode:bicubic}


### PR DESCRIPTION
...o wont miss it now. It causes IE6-8 to wait unnecessarily and puts error in the console.
