### PR TITLE
Large search box improved for smaller screens

### DIFF
--- a/src/css/dgu-shared.less
+++ b/src/css/dgu-shared.less
@@ -575,6 +575,9 @@ h1 .subheading {
     float: left;
     .left-inner {
       background: #fff;
+      @media (max-width: 767px) {
+        background: #efefef;
+      }
       padding: 6px;
       button, input[type="text"] {
         .border-radius(0);
@@ -582,6 +585,12 @@ h1 .subheading {
         box-shadow: none !important;
         height: 50px;
         font-size: 27px;
+        @media (max-width: 767px) {
+          font-size: 21px;
+        }
+        @media (max-width: 370px) {
+          font-size: 16px;
+        }
       }
       i {
         font-size: 25px;
@@ -617,6 +626,12 @@ h1 .subheading {
       }
       .result-count {
           font-size: 40px;
+          @media (max-width: 767px) {
+            font-size: 30px;
+          }
+          @media (max-width: 370px) {
+            font-size: 21px;
+          }
           text-align: center;
           border: none !important;
           line-height: 30px;

--- a/src/css/dgu-shared.less
+++ b/src/css/dgu-shared.less
@@ -620,6 +620,10 @@ h1 .subheading {
     float: left;
     .right-inner {
       background: #A2A2A2;
+      @media (max-width: 767px) {
+        border: 1px solid #a2a2a2;
+        border-left-width: 0;
+      }
       color: #fff;
       position: relative;
       min-height: 90px;

--- a/src/css/dgu-shared.less
+++ b/src/css/dgu-shared.less
@@ -576,9 +576,14 @@ h1 .subheading {
     .left-inner {
       background: #fff;
       @media (max-width: 767px) {
-        background: #efefef;
+        border: 1px solid #a2a2a2;
+        border-right-width: 0;
       }
       padding: 6px;
+      min-height: 90px;
+      @media (max-width: 767px) {
+        min-height: 64px;
+      }
       button, input[type="text"] {
         .border-radius(0);
         border: none;
@@ -600,6 +605,11 @@ h1 .subheading {
         background-position: 97% 10px;
         background-repeat: no-repeat;
       }
+      input.form-control {
+        @media (max-width: 500px) {
+          padding: 0;
+        }
+      }
     }
   }
   .search-all-label {
@@ -613,6 +623,9 @@ h1 .subheading {
       color: #fff;
       position: relative;
       min-height: 90px;
+      @media (max-width: 767px) {
+        min-height: 64px;
+      }
       padding: 6px;
       .chevron {
           border: 10px solid transparent;

--- a/src/js/dgu-shared.js
+++ b/src/js/dgu-shared.js
@@ -124,10 +124,9 @@ function comments() {
     });
 }
 /*
- * New plugin: Equal height boxes.
+ * New plugin: Equal height boxes - excluding mobile
  * When the parent container is resized (eg. browser resizes,
  * hitting a breakpoint) each "foo" is set to equal height.
- * eg.
  * <div class="dgu-equal-height" data-selector="foo">
  *   <div class="foo"> ... </div>
  *   <div class="foo"> ... </div>
@@ -145,17 +144,44 @@ $(function() {
       if (newWidth==cachedWidth) { return; }
       cachedWidth = newWidth;
       children.height('auto');
-      // Affect only browser windows
-      if (w.width()>=992) {
-	var maxHeight = 0;
-        children.each(function(i,x){ maxHeight=Math.max(maxHeight,$(x).height())});
-        children.height(maxHeight);
-      }
+    	var maxHeight = 0;
+      children.each(function(i,x){ maxHeight=Math.max(maxHeight,$(x).height())});
+      children.height(maxHeight);
     }
     if (children.length>1) {
       w.resize( resizeChildren );
       resizeChildren();
     }
+  });
+});
+/* Equal height boxes BUT only on desktop screen sizes (for small objects) 
+ *
+ * This function only resizes when on a desktop screen, since on a mobile the
+ * things being resized would no longer be next to each other.
+ * eg.
+*/
+ (function() {
+  var w = $(window);
+  $('.dgu-equal-height-on-desktop').each(function(i,target) {
+    target = $(target);
+    var selector = target.attr('data-selector');
+    var children = target.find(selector);
+    var cachedWidth = -1;
+    function resizeChildren() {
+      var newWidth = target.width();
+      if (newWidth==cachedWidth) { return; }
+      cachedWidth = newWidth;
+      children.height('auto');
+      var maxHeight = 0;
+      // Affect only desktop windows
+      if (w.width()>=992) {
+        children.each(function(i,x){ maxHeight=Math.max(maxHeight,$(x).height())});
+        console.log(maxHeight);
+        children.height(maxHeight);
+      }
+    }
+    w.resize( resizeChildren );
+    resizeChildren();
   });
 });
 


### PR DESCRIPTION
Large search box seen at: /publisher, /publisher/cabinet-office, /apps, /blog

Improvements for smaller screens:
* now has a border
* smaller text so it fits

Before (/publisher on iphone 6):
<img width="283" alt="screen shot 2016-05-17 at 16 35 40" src="https://cloud.githubusercontent.com/assets/307612/15328636/778faade-1c4d-11e6-8669-41ae1c7f88ea.png">


After:
<img width="283" alt="screen shot 2016-05-17 at 16 35 31" src="https://cloud.githubusercontent.com/assets/307612/15328631/74fddeee-1c4d-11e6-92c9-fb7ae2809365.png">
